### PR TITLE
Hdf display fix

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Batsrus"
 uuid = "e74ebddf-6ac1-4047-a0e5-c32c99e57753"
 authors = ["Hongyang Zhou <hyzhou@umich.edu>"]
-version = "0.8.2"
+version = "0.8.3"
 
 [deps]
 DimensionalData = "0703355e-b756-11e9-17c0-8b28908087d0"

--- a/src/hdf.jl
+++ b/src/hdf.jl
@@ -110,7 +110,7 @@ function Base.show(io::IO, file::BatsrusHDF5Uniform)
    println(io, "Time                     : ", file.common.time)
    vars = HDF5.keys(file.common.fid)
    idBegin_ = findfirst(x->x == "bounding box", vars) + 1
-   idEnd_ = findlast(x->x == "iCoord_DB", vars) - 1
+   idEnd_ = findfirst(x -> endswith(x, "Ext"), vars) - 1
    println(io, "Variables                : ", vars[idBegin_:idEnd_])
 end
 


### PR DESCRIPTION
The old and new BATSRUS hdf5 outputs have different names for the variables. This PR tries to be compatible with the old format as well as the new format.