### PR TITLE
Add imshow

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Batsrus"
 uuid = "e74ebddf-6ac1-4047-a0e5-c32c99e57753"
 authors = ["Hongyang Zhou <hyzhou@umich.edu>"]
-version = "0.8.4"
+version = "0.8.5"
 
 [deps]
 DimensionalData = "0703355e-b756-11e9-17c0-8b28908087d0"

--- a/docs/src/man/manual.md
+++ b/docs/src/man/manual.md
@@ -198,6 +198,7 @@ For 2D outputs, we can select the following functions:
 
 - `contour`
 - `contourf`
+- `imshow`
 - `pcolormesh`
 - `plot_surface`
 - `plot_tricontour`

--- a/src/plot/pyplot.jl
+++ b/src/plot/pyplot.jl
@@ -363,7 +363,7 @@ end
 
 
 """
-    pcolormesh(data, var, levels=0; ax=nothing, plotrange=[-Inf,Inf,-Inf,Inf],
+    pcolormesh(data, var, ax=nothing; plotrange=[-Inf,Inf,-Inf,Inf],
        plotinterval=0.1, innermask=false, vmin=-Inf, vmax=Inf, colorscale=:linear,
        add_colorbar=true, kwargs...)
 
@@ -392,7 +392,7 @@ function PyPlot.pcolormesh(bd::BATS{2, TV, TX, TW}, var::AbstractString, ax=noth
 end
 
 """
-    tripcolor(data, var, levels=0; ax=nothing, plotrange=[-Inf,Inf,-Inf,Inf],
+    tripcolor(data, var, ax=nothing; plotrange=[-Inf,Inf,-Inf,Inf],
        plotinterval=0.1, innermask=false, kwargs...)
 
 Wrapper over `tripcolor` in matplotlib.
@@ -439,6 +439,33 @@ function PyPlot.tripcolor(bd::BATS{2, TV, TX, TW}, var::AbstractString, ax=nothi
    c
 end
 
+"""
+    imshow(data, var, ax=nothing; plotrange=[-Inf,Inf,-Inf,Inf], plotinterval=0.1,
+       innermask=false, colorscale=:linear, add_colorbar=true, kwargs...)
+
+# Keywords
+- `rbody=1.0`: inner body radius.
+- `colorscale::Symbol`: colormap scale from [`:linear`, `:log`].
+- `add_colorbar=true`: turn on colorbar.
+
+Wrapper over `imshow` in matplotlib. For large matrices, this is faster than `pcolormesh`.
+"""
+function PyPlot.imshow(bd::BATS{2, TV, TX, TW}, var::AbstractString, ax=nothing;
+   plotrange=[-Inf,Inf,-Inf,Inf], plotinterval=0.1, innermask=false, rbody=1.0,
+   add_colorbar=true, kwargs...) where {TV, TX, TW}
+   xi, yi, Wi = interp2d(bd, var, plotrange, plotinterval; innermask, rbody)
+
+   if isnothing(ax) ax = plt.gca() end
+
+   c = ax.imshow(Wi; extent=[xi[1], xi[end], yi[1], yi[end]],
+      origin="lower", aspect="auto", interpolation="nearest", kwargs...)
+
+   add_colorbar && colorbar(c; ax, fraction=0.04, pad=0.02)
+
+   add_titles!(bd, var, ax)
+
+   c
+end
 
 """
     streamplot(bd, var, ax=nothing; plotrange=[-Inf,Inf,-Inf,Inf], plotinterval=0.1,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -201,6 +201,8 @@ end
          @test isa(gca(), PyPlot.PyObject)
          p = PyPlot.pcolormesh(bd, "p").get_array()
          @test p[end] == 0.1f0
+         p = PyPlot.imshow(bd, "p").get_array()
+         @test p[2,128] == 0.51229393f0
          plt.close()
          fig = plt.figure()
          ax = fig.add_subplot(111, projection="3d")


### PR DESCRIPTION
For large matrices, `imshow` is faster than `pcolormesh`. Based on a test in Python on my laptop:

<details>
  <summary>Source Code</summary>

  ```python
import matplotlib.pyplot as plt
import numpy as np
import time # Import the time module

# Sample data: Replace with your actual data
# Using larger data to make timing differences more apparent
data_rows = 150
data_cols = 100
x = np.arange(data_cols)
y = np.arange(data_rows)
X, Y = np.meshgrid(x, y)
Z = np.random.rand(data_rows, data_cols) # Generate random data

# --- Time pcolormesh ---
fig = plt.figure(figsize=(12, 6)) # Create the figure once

# pcolormesh plot
ax1 = fig.add_subplot(1, 2, 1)
start_time_pcolormesh = time.time() # Record start time
pcm = ax1.pcolormesh(X, Y, Z, shading='auto') # Execute pcolormesh
end_time_pcolormesh = time.time()   # Record end time
ax1.set_title('pcolormesh Plot')
# fig.colorbar(pcm, ax=ax1) # Optional: Add colorbar

# --- Time imshow ---
ax2 = fig.add_subplot(1, 2, 2)
start_time_imshow = time.time() # Record start time
im = ax2.imshow(Z, extent=[x.min(), x.max(), y.min(), y.max()], origin='lower', aspect='auto', interpolation='nearest') # Execute imshow
end_time_imshow = time.time()   # Record end time
ax2.set_title('imshow Plot')
# fig.colorbar(im, ax=ax2) # Optional: Add colorbar

# --- Calculate and Print Durations ---
duration_pcolormesh = end_time_pcolormesh - start_time_pcolormesh
duration_imshow = end_time_imshow - start_time_imshow

print(f"Time taken for pcolormesh: {duration_pcolormesh:.6f} seconds")
print(f"Time taken for imshow:     {duration_imshow:.6f} seconds")

# --- Display Plot ---
plt.tight_layout()
plt.show()
```

</details>

```
data_rows = 1500
data_cols = 1000
Time taken for pcolormesh: 0.201823 seconds
Time taken for imshow:     0.008048 seconds
```

```
data_rows = 150
data_cols = 100
Time taken for pcolormesh: 0.003990 seconds
Time taken for imshow:     0.001005 seconds
```

