### PR TITLE
Feat: Add coordinate ranges to DimArrays in BATS struct

### DIFF
--- a/ext/BatsrusMakieExt/typerecipe.jl
+++ b/ext/BatsrusMakieExt/typerecipe.jl
@@ -3,7 +3,7 @@
 """
 Conversion for 1D plots
 """
-function Makie.convert_arguments(P::Makie.PointBased, bd::BATS, var::String)
+function Makie.convert_arguments(P::Makie.PointBased, bd::AbstractBATS, var::String)
    var_ = findindex(bd, var)
    if hasunit(bd)
       unitx = getunit(bd, bd.head.wname[1])
@@ -21,7 +21,7 @@ end
 """
 Conversion for 2D plots.
 """
-function Makie.convert_arguments(P::Makie.GridBased, bd::BATS, var::String;
+function Makie.convert_arguments(P::Makie.GridBased, bd::AbstractBATS, var::String;
       plotrange = [-Inf, Inf, -Inf, Inf], plotinterval = 0.1)
    x, y, w = interp2d(bd, var, plotrange, plotinterval)
 

--- a/src/Batsrus.jl
+++ b/src/Batsrus.jl
@@ -12,7 +12,7 @@ using StaticArrays: SVector, @SMatrix, SA, MVector
 using DimensionalData
 using ProgressMeter
 
-export BATS,
+export AbstractBATS, BATSCartesian, BATSUnstructured,
        load, readlogdata, readtecdata, showhead, # io
        getvar, cutdata, subvolume, subsurface, get_convection_E, get_hall_E, get_timeseries,
        get_anisotropy, get_vectors, get_magnitude, get_magnitude2,

--- a/src/io.jl
+++ b/src/io.jl
@@ -38,7 +38,11 @@ function load(file::AbstractString; npict::Int = 1, verbose::Bool = false)
 
    #setunits(head,"")
 
-   BATS(head, filelist, x, w)
+   if head.gencoord
+      BATSUnstructured(head, filelist, x, w)
+   else
+      BATSCartesian(head, filelist, x, w)
+   end
 end
 
 """
@@ -695,7 +699,7 @@ function setunits(head::BatsHead, type; distance = 1.0, mp = 1.0, me = 1.0)
    return true
 end
 
-function Base.show(io::IO, data::BATS)
+function Base.show(io::IO, data::AbstractBATS)
    showhead(io, data)
    if data.list.bytes ≥ 1e9
       str = @sprintf "filesize: %.1f GB" data.list.bytes/1e9
@@ -758,5 +762,5 @@ end
 
 Display file information of `data`.
 """
-showhead(data::BATS) = showhead(data.list, data.head)
-showhead(io::IO, data::BATS) = showhead(data.list, data.head, io)
+showhead(data::AbstractBATS) = showhead(data.list, data.head)
+showhead(io::IO, data::AbstractBATS) = showhead(data.list, data.head, io)

--- a/src/plot/plots.jl
+++ b/src/plot/plots.jl
@@ -3,44 +3,41 @@
 using RecipesBase
 
 # Build a recipe which acts on a custom type.
-@recipe function f(bd::BATS{1, TV, TX, TW}, var::AbstractString) where {TV, TX, TW}
+@recipe function f(bd::AbstractBATS, var::AbstractString;
+      plotrange = [-Inf, Inf, -Inf, Inf], plotinterval = 0.1)
    hasunits = hasunit(bd)
-
-   if hasunits
-      unitx = getunit(bd, bd.head.wname[1])
-      unitw = getunit(bd, var)
-      x = bd.x .* unitx
-      y = getview(bd, var) .* unitw
-   else
-      x = bd.x
-      y = getview(bd, var)
-   end
-
-   @series begin
-      seriestype --> :path
-      x, y
-   end
-end
-
-@recipe function f(bd::BATS{2, TV, TX, TW}, var::AbstractString;
-      plotrange = [-Inf, Inf, -Inf, Inf], plotinterval = 0.1) where {TV, TX, TW}
-   hasunits = hasunit(bd)
-
-   x, y, w = interp2d(bd, var, plotrange, plotinterval)
-   if hasunits
-      unitx = getunit(bd, bd.head.wname[1])
-      unity = getunit(bd, bd.head.wname[2])
-      unitw = getunit(bd, var)
-
-      if unitx isa UnitfulBatsrus.Unitlike
-         x *= unitx
-         y *= unity
-         w *= unitw
+   if bd.head.ndim == 1
+      if hasunits
+         unitx = getunit(bd, bd.head.wname[1])
+         unitw = getunit(bd, var)
+         x = bd.x .* unitx
+         y = getview(bd, var) .* unitw
+      else
+         x = bd.x
+         y = getview(bd, var)
       end
-   end
 
-   @series begin
-      seriestype --> :contourf  # use := if you want to force it
-      x, y, w'
+      @series begin
+         seriestype --> :path
+         x, y
+      end
+   elseif bd.head.ndim == 2
+      x, y, w = interp2d(bd, var, plotrange, plotinterval)
+      if hasunits
+         unitx = getunit(bd, bd.head.wname[1])
+         unity = getunit(bd, bd.head.wname[2])
+         unitw = getunit(bd, var)
+
+         if unitx isa UnitfulBatsrus.Unitlike
+            x *= unitx
+            y *= unity
+            w *= unitw
+         end
+      end
+
+      @series begin
+         seriestype --> :contourf  # use := if you want to force it
+         x, y, w'
+      end
    end
 end

--- a/src/plot/pyplot.jl
+++ b/src/plot/pyplot.jl
@@ -54,16 +54,17 @@ function plotlogdata(data, head::NamedTuple, func::AbstractString; plotmode = "l
 end
 
 """
-     plotgrid(bd::BATS, var, ax=nothing; kwargs...)
+     plotgrid(bd::AbstractBATS, var, ax=nothing; kwargs...)
 
 Plot 2D mesh.
 """
 function plotgrid(
-      bd::BATS{2, TV, TX, TW},
+      bd::AbstractBATS,
       func::AbstractString,
       ax = nothing;
       kwargs...
-) where {TV, TX, TW}
+)
+   bd.head.ndim != 2 && error("plotgrid only works for 2D data!")
    if isnothing(ax)
       ax = plt.gca()
    end
@@ -85,8 +86,9 @@ end
 
 2D plane cut pcolormesh of 3D box data. `sequence` is the index along `dir`.
 """
-function cutplot(bd::BATS{3, TV, TX, TW}, var::AbstractString, ax = nothing;
-      plotrange = [-Inf, Inf, -Inf, Inf], dir = "x", sequence = 1) where {TV, TX, TW}
+function cutplot(bd::AbstractBATS, var::AbstractString, ax = nothing;
+      plotrange = [-Inf, Inf, -Inf, Inf], dir = "x", sequence = 1)
+   bd.head.ndim != 3 && error("cutplot only works for 3D data!")
    x, w = bd.x, bd.w
    varIndex_ = findindex(bd, var)
 
@@ -135,15 +137,16 @@ function cutplot(bd::BATS{3, TV, TX, TW}, var::AbstractString, ax = nothing;
 end
 
 """
-     streamslice(data::BATS, var, ax=nothing; plotrange=[-Inf,Inf,-Inf,Inf], dir="x",
+     streamslice(data::AbstractBATS, var, ax=nothing; plotrange=[-Inf,Inf,-Inf,Inf], dir="x",
     	 sequence=1; kwargs...)
 
 Plot streamlines on 2D slices of 3D box data. Variable names in `var` string must be
 separated with `;`.
 """
-function streamslice(bd::BATS{3, TV, TX, TW}, var::AbstractString, ax = nothing;
+function streamslice(bd::AbstractBATS, var::AbstractString, ax = nothing;
       plotrange = [-Inf, Inf, -Inf, Inf], dir = "x", sequence = 1, kwargs...
-) where {TV, TX, TW}
+)
+   bd.head.ndim != 3 && error("streamslice only works for 3D data!")
    x, w = bd.x, bd.w
    varstream = split(var, ";")
    var1_ = findindex(bd, varstream[1])
@@ -200,16 +203,17 @@ function streamslice(bd::BATS{3, TV, TX, TW}, var::AbstractString, ax = nothing;
 end
 
 """
-     plot(bd::BATS{1, TV, T}, var, ax=nothing; kwargs...)
+     plot(bd::AbstractBATS, var, ax=nothing; kwargs...)
 
 Wrapper over `plot` in matplotlib. Plot 1D outputs.
 """
 function PyPlot.plot(
-      bd::BATS{1, TV, TX, TW},
+      bd::AbstractBATS,
       var::AbstractString,
       ax = nothing;
       kwargs...
-) where {TV, TX, TW}
+)
+   bd.head.ndim != 1 && error("plot only works for 1D data!")
    x, w = bd.x, bd.w
    varIndex_ = findindex(bd, var)
    if isnothing(ax)
@@ -231,11 +235,12 @@ end
 Wrapper over `scatter` in matplotlib.
 """
 function PyPlot.scatter(
-      bd::BATS{1, TV, TX, TW},
+      bd::AbstractBATS,
       var::AbstractString,
       ax = nothing;
       kwargs...
-) where {TV, TX, TW}
+)
+   bd.head.ndim != 1 && error("scatter only works for 1D data!")
    x, w = bd.x, bd.w
    varIndex_ = findindex(bd, var)
    if isnothing(ax)
@@ -251,10 +256,11 @@ end
 
 Wrapper over `contour` in matplotlib.
 """
-function PyPlot.contour(bd::BATS{2, TV, TX, TW}, var::AbstractString, ax = nothing;
+function PyPlot.contour(bd::AbstractBATS, var::AbstractString, ax = nothing;
       levels = 0,
       plotrange = [-Inf, Inf, -Inf, Inf], plotinterval = 0.1, innermask = false, rbody = 1.0,
-      kwargs...) where {TV, TX, TW}
+      kwargs...)
+   bd.head.ndim != 2 && error("contour only works for 2D data!")
    Xi, Yi, Wi = interp2d(bd, var, plotrange, plotinterval; innermask, rbody)
    if isnothing(ax)
       ax = plt.gca()
@@ -277,11 +283,12 @@ end
 
 Wrapper over `contourf` in matplotlib. See [`interp2d`](@ref) for some related keywords.
 """
-function PyPlot.contourf(bd::BATS{2, TV, TX, TW}, var::AbstractString, ax = nothing;
+function PyPlot.contourf(bd::AbstractBATS, var::AbstractString, ax = nothing;
       levels::Int = 0,
       plotrange = [-Inf, Inf, -Inf, Inf], plotinterval = 0.1, innermask = false, rbody = 1.0,
       add_colorbar = true, vmin = -Inf, vmax = Inf, colorscale = :linear, kwargs...
-) where {TV, TX, TW}
+)
+   bd.head.ndim != 2 && error("contourf only works for 2D data!")
    Xi, Yi, Wi = interp2d(bd, var, plotrange, plotinterval; innermask, rbody)
    if isnothing(ax)
       ax = plt.gca()
@@ -304,8 +311,9 @@ end
 
 Wrapper over `tricontourf` in matplotlib.
 """
-function PyPlot.tricontourf(bd::BATS{2, TV, TX, TW}, var::AbstractString, ax = nothing;
-      plotrange = [-Inf, Inf, -Inf, Inf], kwargs...) where {TV, TX, TW}
+function PyPlot.tricontourf(bd::AbstractBATS, var::AbstractString, ax = nothing;
+      plotrange = [-Inf, Inf, -Inf, Inf], kwargs...)
+   bd.head.ndim != 2 && error("tricontourf only works for 2D data!")
    x, w = bd.x, bd.w
    varIndex_ = findindex(bd, var)
 
@@ -332,9 +340,10 @@ function PyPlot.tricontourf(bd::BATS{2, TV, TX, TW}, var::AbstractString, ax = n
    c
 end
 
-function PyPlot.triplot(bd::BATS{2, TV, TX, TW}, ax = nothing;
+function PyPlot.triplot(bd::AbstractBATS, ax = nothing;
       plotrange = [-Inf, Inf, -Inf, Inf],
-      kwargs...) where {TV, TX, TW}
+      kwargs...)
+   bd.head.ndim != 2 && error("triplot only works for 2D data!")
    X = vec(bd.x[:, :, 1])
    Y = vec(bd.x[:, :, 2])
    triang = matplotlib.tri.Triangulation(X, Y)
@@ -353,13 +362,14 @@ function PyPlot.triplot(bd::BATS{2, TV, TX, TW}, ax = nothing;
 end
 
 """
-     plot_trisurf(data::BATS, var::String, ax=nothing; plotrange=[-Inf,Inf,-Inf,Inf],
+     plot_trisurf(data::AbstractBATS, var::String, ax=nothing; plotrange=[-Inf,Inf,-Inf,Inf],
     	 kwargs...)
 
 Wrapper over `plot_trisurf` in matplotlib.
 """
-function PyPlot.plot_trisurf(bd::BATS{2, TV, TX, TW}, var::AbstractString;
-      plotrange = [-Inf, Inf, -Inf, Inf], kwargs...) where {TV, TX, TW}
+function PyPlot.plot_trisurf(bd::AbstractBATS, var::AbstractString;
+      plotrange = [-Inf, Inf, -Inf, Inf], kwargs...)
+   bd.head.ndim != 2 && error("plot_trisurf only works for 2D data!")
    x, w = bd.x, bd.w
    varIndex_ = findindex(bd, var)
 
@@ -393,9 +403,10 @@ end
 
 Wrapper over `plot_surface` in matplotlib.
 """
-function PyPlot.plot_surface(bd::BATS{2, TV, TX, TW}, var::AbstractString, ax = nothing;
+function PyPlot.plot_surface(bd::AbstractBATS, var::AbstractString, ax = nothing;
       plotrange = [-Inf, Inf, -Inf, Inf], plotinterval = 0.1, innermask = false, rbody = 1.0,
-      kwargs...) where {TV, TX, TW}
+      kwargs...)
+   bd.head.ndim != 2 && error("plot_surface only works for 2D data!")
    if isnothing(ax)
       ax = plt.gca()
    end
@@ -422,10 +433,11 @@ end
 
 Wrapper over `pcolormesh` in matplotlib.
 """
-function PyPlot.pcolormesh(bd::BATS{2, TV, TX, TW}, var::AbstractString, ax = nothing;
+function PyPlot.pcolormesh(bd::AbstractBATS, var::AbstractString, ax = nothing;
       plotrange = [-Inf, Inf, -Inf, Inf], plotinterval = 0.1, innermask = false, rbody = 1.0,
       vmin = -Inf, vmax = Inf, colorscale = :linear, add_colorbar = true, kwargs...
-) where {TV, TX, TW}
+)
+   bd.head.ndim != 2 && error("pcolormesh only works for 2D data!")
    xi, yi, Wi = interp2d(bd, var, plotrange, plotinterval; innermask, rbody)
 
    if isnothing(ax)
@@ -448,8 +460,9 @@ end
 
 Wrapper over `tripcolor` in matplotlib.
 """
-function PyPlot.tripcolor(bd::BATS{2, TV, TX, TW}, var::AbstractString, ax = nothing;
-      plotrange = [-Inf, Inf, -Inf, Inf], innermask = false, kwargs...) where {TV, TX, TW}
+function PyPlot.tripcolor(bd::AbstractBATS, var::AbstractString, ax = nothing;
+      plotrange = [-Inf, Inf, -Inf, Inf], innermask = false, kwargs...)
+   bd.head.ndim != 2 && error("tripcolor only works for 2D data!")
    x, w = bd.x, bd.w
 
    varIndex_ = findindex(bd, var)
@@ -506,9 +519,10 @@ end
 
 Wrapper over `imshow` in matplotlib. For large matrices, this is faster than `pcolormesh`.
 """
-function PyPlot.imshow(bd::BATS{2, TV, TX, TW}, var::AbstractString, ax = nothing;
+function PyPlot.imshow(bd::AbstractBATS, var::AbstractString, ax = nothing;
       plotrange = [-Inf, Inf, -Inf, Inf], plotinterval = 0.1, innermask = false, rbody = 1.0,
-      add_colorbar = true, vmin = -Inf, vmax = Inf, colorscale=:linear, kwargs...) where {TV, TX, TW}
+      add_colorbar = true, vmin = -Inf, vmax = Inf, colorscale=:linear, kwargs...)
+   bd.head.ndim != 2 && error("imshow only works for 2D data!")
    xi, yi, Wi = interp2d(bd, var, plotrange, plotinterval; innermask, rbody)
 
    if isnothing(ax)
@@ -532,8 +546,9 @@ end
 
 Wrapper over `streamplot` in matplotlib.
 """
-function PyPlot.streamplot(bd::BATS{2, TV, TX, TW}, var::AbstractString, ax = nothing;
-      plotrange = [-Inf, Inf, -Inf, Inf], plotinterval = Inf, kwargs...) where {TV, TX, TW}
+function PyPlot.streamplot(bd::AbstractBATS, var::AbstractString, ax = nothing;
+      plotrange = [-Inf, Inf, -Inf, Inf], plotinterval = Inf, kwargs...)
+   bd.head.ndim != 2 && error("streamplot only works for 2D data!")
    xi, yi, v1, v2 = _getvector(bd, var; plotrange, plotinterval)
 
    if isnothing(ax)
@@ -543,8 +558,9 @@ function PyPlot.streamplot(bd::BATS{2, TV, TX, TW}, var::AbstractString, ax = no
    ax.streamplot(xi, yi, v1, v2; kwargs...)
 end
 
-function _getvector(bd::BATS{2, TV, TX, TW}, var::AbstractString;
-      plotrange = [-Inf, Inf, -Inf, Inf], plotinterval = Inf) where {TV, TX, TW}
+function _getvector(bd::AbstractBATS, var::AbstractString;
+      plotrange = [-Inf, Inf, -Inf, Inf], plotinterval = Inf)
+   bd.head.ndim != 2 && error("_getvector only works for 2D data!")
    x, w = bd.x, bd.w
    varstream = split(var, ";")
    var1_ = findfirst(x->lowercase(x)==lowercase(varstream[1]), bd.head.wname)
@@ -600,8 +616,9 @@ end
 
 Wrapper over `quiver` in matplotlib. Only supports Cartesian grid for now.
 """
-function PyPlot.quiver(bd::BATS{2, TV, TX, TW}, var::AbstractString, ax = nothing;
-      stride::Integer = 10, kwargs...) where {TV, TX, TW}
+function PyPlot.quiver(bd::AbstractBATS, var::AbstractString, ax = nothing;
+      stride::Integer = 10, kwargs...)
+   bd.head.ndim != 2 && error("quiver only works for 2D data!")
    x, w = bd.x, bd.w
    VarQuiver = split(var, ";")
    var1_ = findindex(bd, VarQuiver[1])
@@ -642,7 +659,7 @@ function set_colorbar(colorscale, vmin, vmax, data = [1.0])
    cnorm
 end
 
-function add_titles!(bd::BATS, var, ax)
+function add_titles!(bd::AbstractBATS, var, ax)
    varIndex_ = findindex(bd, var)
    title(bd.head.wname[varIndex_])
 
@@ -651,7 +668,7 @@ function add_titles!(bd::BATS, var, ax)
    add_time_iteration!(bd, ax)
 end
 
-function add_time_iteration!(bd::BATS, ax)
+function add_time_iteration!(bd::AbstractBATS, ax)
    str = @sprintf "it=%d, time=%4.2f" bd.head.it bd.head.time
    at = matplotlib.offsetbox.AnchoredText(str,
       loc = "lower left", prop = Dict("size"=>8), frameon = true,

--- a/src/type.jl
+++ b/src/type.jl
@@ -38,10 +38,8 @@ struct BatsHead
    param::Vector{SubString{String}}
 end
 
-"""
-Batsrus data container, with `Dim` being the dimension of output.
-"""
-struct BATS{Dim, TV <: AbstractFloat, TX, TW} <: AbstractBATS{Dim, TV}
+"Cartesian grid data."
+struct BATSCartesian{Dim, TV <: AbstractFloat, TX, TW} <: AbstractBATS{Dim, TV}
    head::BatsHead
    list::FileList
    "Grid"
@@ -49,7 +47,7 @@ struct BATS{Dim, TV <: AbstractFloat, TX, TW} <: AbstractBATS{Dim, TV}
    "Variables"
    w::TW
 
-   function BATS(head, list, x::Array{TV, Dimp1}, w::Array{TV, Dimp1}) where {TV, Dimp1}
+   function BATSCartesian(head, list, x::Array{TV, Dimp1}, w::Array{TV, Dimp1}) where {TV, Dimp1}
       @assert head.ndim + 1 == Dimp1 "Dimension mismatch!"
       if head.ndim == 2
          xrange, yrange = get_range(x)
@@ -63,6 +61,32 @@ struct BATS{Dim, TV <: AbstractFloat, TX, TW} <: AbstractBATS{Dim, TV}
          (xrange,) = get_range(x)
          x = DimArray(x, (X(xrange), :dim))
          w = DimArray(w, (X(xrange), Dim{:var}(head.wname)))
+      end
+
+      new{head.ndim, TV, typeof(x), typeof(w)}(head, list, x, w)
+   end
+end
+
+"Unstructured grid data."
+struct BATSUnstructured{Dim, TV <: AbstractFloat, TX, TW} <: AbstractBATS{Dim, TV}
+   head::BatsHead
+   list::FileList
+   "Grid"
+   x::TX
+   "Variables"
+   w::TW
+
+   function BATSUnstructured(head, list, x::Array{TV, Dimp1}, w::Array{TV, Dimp1}) where {TV, Dimp1}
+      @assert head.ndim + 1 == Dimp1 "Dimension mismatch!"
+      if head.ndim == 2
+         x = DimArray(x, (X, Y, :dim))
+         w = DimArray(w, (X, Y, Dim{:var}(head.wname)))
+      elseif head.ndim == 3
+         x = DimArray(x, (X, Y, Z, :dim))
+         w = DimArray(w, (X, Y, Z, Dim{:var}(head.wname)))
+      elseif head.ndim == 1
+         x = DimArray(x, (X, :dim))
+         w = DimArray(w, (X, Dim{:var}(head.wname)))
       end
 
       new{head.ndim, TV, typeof(x), typeof(w)}(head, list, x, w)

--- a/src/type.jl
+++ b/src/type.jl
@@ -52,14 +52,17 @@ struct BATS{Dim, TV <: AbstractFloat, TX, TW} <: AbstractBATS{Dim, TV}
    function BATS(head, list, x::Array{TV, Dimp1}, w::Array{TV, Dimp1}) where {TV, Dimp1}
       @assert head.ndim + 1 == Dimp1 "Dimension mismatch!"
       if head.ndim == 2
-         x = DimArray(x, (X, Y, :dim))
-         w = DimArray(w, (X, Y, Dim{:var}(head.wname)))
+         xrange, yrange = get_range(x)
+         x = DimArray(x, (X(xrange), Y(yrange), :dim))
+         w = DimArray(w, (X(xrange), Y(yrange), Dim{:var}(head.wname)))
       elseif head.ndim == 3
-         x = DimArray(x, (X, Y, Z, :dim))
-         w = DimArray(w, (X, Y, Z, Dim{:var}(head.wname)))
+         xrange, yrange, zrange = get_range(x)
+         x = DimArray(x, (X(xrange), Y(yrange), Z(zrange), :dim))
+         w = DimArray(w, (X(xrange), Y(yrange), Z(zrange), Dim{:var}(head.wname)))
       elseif head.ndim == 1
-         x = DimArray(x, (X, :dim))
-         w = DimArray(w, (X, Dim{:var}(head.wname)))
+         (xrange,) = get_range(x)
+         x = DimArray(x, (X(xrange), :dim))
+         w = DimArray(w, (X(xrange), Dim{:var}(head.wname)))
       end
 
       new{head.ndim, TV, typeof(x), typeof(w)}(head, list, x, w)

--- a/src/utility.jl
+++ b/src/utility.jl
@@ -252,6 +252,30 @@ get_var_range(bd::BATS, var) = getview(bd, var) |> extrema
 """
 Return mesh range of `bd`.
 """
+function get_range(x::Array{T, 3}) where T
+   x_coords = @view x[:,:,1]
+   y_coords = @view x[:,:,2]
+   xrange = range(extrema(x_coords)..., length = size(x, 1))
+   yrange = range(extrema(y_coords)..., length = size(x, 2))
+   xrange, yrange
+end
+
+function get_range(x::Array{T, 4}) where T
+   x_coords = @view x[:,:,:,1]
+   y_coords = @view x[:,:,:,2]
+   z_coords = @view x[:,:,:,3]
+   xrange = range(extrema(x_coords)..., length = size(x, 1))
+   yrange = range(extrema(y_coords)..., length = size(x, 2))
+   zrange = range(extrema(z_coords)..., length = size(x, 3))
+   xrange, yrange, zrange
+end
+
+function get_range(x::Array{T, 2}) where T
+   x_coords = @view x[:,1]
+   xrange = range(extrema(x_coords)..., length = size(x, 1))
+   (xrange,)
+end
+
 function get_range(bd::BATS{2, TV, TX, TW}) where {TV, TX, TW}
    x = bd.x
    xrange = range(x[1, 1, 1], x[end, 1, 1], length = size(x, 1))


### PR DESCRIPTION
The BATS struct uses DimArrays from DimensionalData.jl to store coordinates and variables. Previously, the DimArrays were created without specifying the coordinate ranges, which prevented the use of selector methods from DimensionalData.jl.

This change modifies the BATS constructor to calculate the coordinate ranges from the input coordinate array `x` and includes them in the DimArray creation. New `get_range` functions that operate on the raw `x` array have been added to `src/utility.jl`. These coexist with the original `get_range` functions that take a BATS object as input, as requested.

This allows for the proper use of selector methods, for example `bd.w[X(1.0..2.0)]`.