### PR TITLE
refactor: return DimArray for derived variables

### DIFF
--- a/ext/BatsrusMakieExt/BatsrusMakieExt.jl
+++ b/ext/BatsrusMakieExt/BatsrusMakieExt.jl
@@ -9,8 +9,19 @@ using Makie: @L_str, heatmap!, poly!, Circle, Point2f, Figure, Axis, Colorbar,
     colgap!, DataAspect, save, delete!, Observable
 using Unitful: ustrip
 using DimensionalData: dims, val
+using PrecompileTools: @setup_workload, @compile_workload
 
 include("typerecipe.jl")
 include("makie_amrex.jl")
+
+@setup_workload begin
+    # Mock data for precompilation
+    file = joinpath(@__DIR__, "../../test/precompile.out")
+    bd = file |> load
+    @compile_workload begin
+        # Precompile common plotting functions
+        Makie.heatmap(bd, "rho")
+    end
+end
 
 end

--- a/ext/BatsrusMakieExt/BatsrusMakieExt.jl
+++ b/ext/BatsrusMakieExt/BatsrusMakieExt.jl
@@ -15,10 +15,10 @@ include("typerecipe.jl")
 include("makie_amrex.jl")
 
 @setup_workload begin
-    # Mock data for precompilation
-    file = joinpath(@__DIR__, "../../test/precompile.out")
-    bd = file |> load
     @compile_workload begin
+        # Mock data for precompilation
+        file = joinpath(@__DIR__, "../../test/precompile.out")
+        bd = file |> load
         # Precompile common plotting functions
         Makie.heatmap(bd, "rho")
     end

--- a/ext/BatsrusMakieUniformStreamlinesExt/BatsrusMakieUniformStreamlinesExt.jl
+++ b/ext/BatsrusMakieUniformStreamlinesExt/BatsrusMakieUniformStreamlinesExt.jl
@@ -14,11 +14,12 @@ using PrecompileTools: @setup_workload, @compile_workload
 include("animate.jl")
 
 @setup_workload begin
-    # Mock data for precompilation
-    file = joinpath(@__DIR__, "../../test/precompile.out")
     @compile_workload begin
-        # Precompile common plotting functions
-        animate([file], "rho"; showplot = false, save_as = "")
+        mktempdir() do tmpdir
+            # Mock data for precompilation
+            file = joinpath(@__DIR__, "../../test/precompile.out")
+            animate([file]; var = :rho)
+        end
     end
 end
 

--- a/ext/BatsrusMakieUniformStreamlinesExt/BatsrusMakieUniformStreamlinesExt.jl
+++ b/ext/BatsrusMakieUniformStreamlinesExt/BatsrusMakieUniformStreamlinesExt.jl
@@ -9,7 +9,18 @@ using Makie: @L_str, heatmap!, poly!, Circle, Point2f, Figure, Axis, Colorbar,
 using DimensionalData: dims, val
 using UniformStreamlines: streamlines!, evenstream
 using ProgressMeter
+using PrecompileTools: @setup_workload, @compile_workload
 
 include("animate.jl")
+
+@setup_workload begin
+    # Mock data for precompilation
+    file = joinpath(@__DIR__, "../../test/precompile.out")
+    bd = file |> load
+    @compile_workload begin
+        # Precompile common plotting functions
+        animate(bd, "rho"; showplot = false, save_as = "")
+    end
+end
 
 end

--- a/ext/BatsrusMakieUniformStreamlinesExt/BatsrusMakieUniformStreamlinesExt.jl
+++ b/ext/BatsrusMakieUniformStreamlinesExt/BatsrusMakieUniformStreamlinesExt.jl
@@ -9,18 +9,7 @@ using Makie: @L_str, heatmap!, poly!, Circle, Point2f, Figure, Axis, Colorbar,
 using DimensionalData: dims, val
 using UniformStreamlines: streamlines!, evenstream
 using ProgressMeter
-using PrecompileTools: @setup_workload, @compile_workload
 
 include("animate.jl")
-
-@setup_workload begin
-    @compile_workload begin
-        mktempdir() do tmpdir
-            # Mock data for precompilation
-            file = joinpath(@__DIR__, "../../test/precompile.out")
-            animate([file]; var = "rho", streamvars = "bx;by")
-        end
-    end
-end
 
 end

--- a/ext/BatsrusMakieUniformStreamlinesExt/BatsrusMakieUniformStreamlinesExt.jl
+++ b/ext/BatsrusMakieUniformStreamlinesExt/BatsrusMakieUniformStreamlinesExt.jl
@@ -18,7 +18,7 @@ include("animate.jl")
         mktempdir() do tmpdir
             # Mock data for precompilation
             file = joinpath(@__DIR__, "../../test/precompile.out")
-            animate([file]; var = :rho)
+            animate([file]; var = "rho", streamvars = "bx;by")
         end
     end
 end

--- a/ext/BatsrusMakieUniformStreamlinesExt/BatsrusMakieUniformStreamlinesExt.jl
+++ b/ext/BatsrusMakieUniformStreamlinesExt/BatsrusMakieUniformStreamlinesExt.jl
@@ -16,10 +16,9 @@ include("animate.jl")
 @setup_workload begin
     # Mock data for precompilation
     file = joinpath(@__DIR__, "../../test/precompile.out")
-    bd = file |> load
     @compile_workload begin
         # Precompile common plotting functions
-        animate(bd, "rho"; showplot = false, save_as = "")
+        animate([file], "rho"; showplot = false, save_as = "")
     end
 end
 

--- a/ext/BatsrusMakieUniformStreamlinesExt/animate.jl
+++ b/ext/BatsrusMakieUniformStreamlinesExt/animate.jl
@@ -9,7 +9,7 @@ Save figures of colored contour from SWMF output files using Makie.
 Uses DimensionalData selectors or interpolation for data extraction.
 
 # Keywords
-- `var::String`: variable to plot with heatmap.
+- `var`: variable to plot with heatmap.
 - `vmin::Real`: minimum plotting value.
 - `vmax::Real`: maximum plotting value.
 - `plotrange`: 2D plotting spatial range `[xmin, xmax, ymin, ymax]`.

--- a/ext/BatsrusPyPlotExt/BatsrusPyPlotExt.jl
+++ b/ext/BatsrusPyPlotExt/BatsrusPyPlotExt.jl
@@ -23,7 +23,8 @@ function __init__()
     PyPlot.matplotlib.rc("xtick", labelsize = 10)
     PyPlot.matplotlib.rc("ytick", labelsize = 10)
     PyPlot.matplotlib.rc("xtick.minor", visible = true)
-    return PyPlot.matplotlib.rc("ytick.minor", visible = true)
+    PyPlot.matplotlib.rc("ytick.minor", visible = true)
+    return
 end
 
 function Batsrus._triangulate_matplotlib(X, Y, W, xi, yi)

--- a/ext/BatsrusPyPlotExt/animate.jl
+++ b/ext/BatsrusPyPlotExt/animate.jl
@@ -9,7 +9,7 @@ Save figures of colored contour from SWMF output files.
 Uses DimensionalData selectors or interpolation for data extraction.
 
 # Keywords
-- `var::String`: variable to plot with pcolormesh.
+- `var`: variable to plot with pcolormesh.
 - `vmin::Real`: minimum plotting value.
 - `vmax::Real`: maximum plotting value.
 - `colorscale::Symbol`: color scale for the plot (`:linear`, `:log`, `:symlog`, `:twoslope`).

--- a/ext/BatsrusWriteVTKExt.jl
+++ b/ext/BatsrusWriteVTKExt.jl
@@ -1,6 +1,7 @@
 module BatsrusWriteVTKExt
 
 using Batsrus, WriteVTK, Glob, LightXML
+using PrecompileTools: @setup_workload, @compile_workload
 using Batsrus: readtecdata, load, Batl, getConnectivity, get_range
 
 """
@@ -299,6 +300,17 @@ function Batsrus.create_pvd(filepattern::String, debug::Bool = false)
     save_file(xdoc, filenames[1][1:name_index] * ".pvd")
 
     return
+end
+
+@setup_workload begin
+    # Mock data for precompilation
+    file = joinpath(@__DIR__, "../test/precompile.out")
+    @compile_workload begin
+        mktempdir() do tmpdir
+            outname = joinpath(tmpdir, "out")
+            convertIDLtoVTK(file; outname)
+        end
+    end
 end
 
 end

--- a/ext/BatsrusWriteVTKExt.jl
+++ b/ext/BatsrusWriteVTKExt.jl
@@ -303,10 +303,10 @@ function Batsrus.create_pvd(filepattern::String, debug::Bool = false)
 end
 
 @setup_workload begin
-    # Mock data for precompilation
-    file = joinpath(@__DIR__, "../test/precompile.out")
     @compile_workload begin
         mktempdir() do tmpdir
+            # Mock data for precompilation
+            file = joinpath(@__DIR__, "../test/precompile.out")
             outname = joinpath(tmpdir, "out")
             convertIDLtoVTK(file; outname)
         end

--- a/src/select.jl
+++ b/src/select.jl
@@ -246,16 +246,16 @@ end
 
 Calculate the magnitude square of vector `var`. See [`get_vectors`](@ref) for the options.
 """
-function get_magnitude2(bd::BatsrusIDL, var = :B)
+function get_magnitude2(bd::BatsrusIDL{ndim}, var = :B) where {ndim}
     ivx, ivy, ivz = get_vectors_indices(bd, var)
     w = parent(bd.w)
-    v_raw = similar(w, size(w, 1), size(w, 2))
+    v_raw = similar(w, size(bd.w)[1:ndim])
 
     @inbounds @simd for i in CartesianIndices(v_raw)
         v_raw[i] = w[i, ivx]^2 + w[i, ivy]^2 + w[i, ivz]^2
     end
 
-    return v_raw
+    return DimArray(v_raw, dims(bd.w)[1:ndim])
 end
 
 """
@@ -263,22 +263,20 @@ end
 
 Calculate the magnitude of vector `var`. See [`get_vectors`](@ref) for the options.
 """
-function get_magnitude(bd::BatsrusIDL, var = :B)
+function get_magnitude(bd::BatsrusIDL{ndim}, var = :B) where {ndim}
     ivx, ivy, ivz = get_vectors_indices(bd, var)
     w = parent(bd.w)
-    v_raw = similar(w, size(w, 1), size(w, 2))
+    v_raw = similar(w, size(bd.w)[1:ndim])
 
     @inbounds @simd for i in CartesianIndices(v_raw)
         v_raw[i] = √(w[i, ivx]^2 + w[i, ivy]^2 + w[i, ivz]^2)
     end
 
-    return v_raw
+    return DimArray(v_raw, dims(bd.w)[1:ndim])
 end
 
 """
-    get_vectors(bd::BatsrusIDL, var)
-
-Return a tuple of vectors of `var`. `var` can be `:B`, `:E`, `:U`, or any `:U` followed by an index (e.g. `:U0` for species 0, `:U1` for species 1, etc.).
+Return a tuple of indices for the vector of `var`. `var` can be `:B`, `:E`, `:U`, or any `:U` followed by an index (e.g. `:U0` for species 0, `:U1` for species 1, etc.).
 """
 function get_vectors_indices(bd::BatsrusIDL, var)
     if var === :B
@@ -352,7 +350,7 @@ function get_anisotropy(bd::BatsrusIDL{2, TV}, species = 0; method = :simple) wh
         end
     end
 
-    return Paniso_raw
+    return DimArray(Paniso_raw, dims(bd.w)[1:2])
 end
 
 """

--- a/src/select.jl
+++ b/src/select.jl
@@ -248,14 +248,14 @@ Calculate the magnitude square of vector `var`. See [`get_vectors`](@ref) for th
 """
 function get_magnitude2(bd::BatsrusIDL{ndim}, var = :B) where {ndim}
     ivx, ivy, ivz = get_vectors_indices(bd, var)
-    w = parent(bd.w)
-    v_raw = similar(w, size(bd.w)[1:ndim])
+    v = similar(bd.w, dims(bd.w)[1:ndim])
+    w, v_raw = parent(bd.w), parent(v)
 
     @inbounds @simd for i in CartesianIndices(v_raw)
         v_raw[i] = w[i, ivx]^2 + w[i, ivy]^2 + w[i, ivz]^2
     end
 
-    return DimArray(v_raw, dims(bd.w)[1:ndim])
+    return v
 end
 
 """
@@ -265,14 +265,14 @@ Calculate the magnitude of vector `var`. See [`get_vectors`](@ref) for the optio
 """
 function get_magnitude(bd::BatsrusIDL{ndim}, var = :B) where {ndim}
     ivx, ivy, ivz = get_vectors_indices(bd, var)
-    w = parent(bd.w)
-    v_raw = similar(w, size(bd.w)[1:ndim])
+    v = similar(bd.w, dims(bd.w)[1:ndim])
+    w, v_raw = parent(bd.w), parent(v)
 
     @inbounds @simd for i in CartesianIndices(v_raw)
         v_raw[i] = √(w[i, ivx]^2 + w[i, ivy]^2 + w[i, ivz]^2)
     end
 
-    return DimArray(v_raw, dims(bd.w)[1:ndim])
+    return v
 end
 
 """
@@ -327,8 +327,8 @@ function get_anisotropy(bd::BatsrusIDL{2, TV}, species = 0; method = :simple) wh
     ipyy, ipzz = ipxx + 1, ipxx + 2
     ipxy, ipxz, ipyz = ipxx + 3, ipxx + 4, ipxx + 5
 
-    w = parent(bd.w)
-    Paniso_raw = similar(w, size(w, 1), size(w, 2))
+    Paniso = similar(bd.w, dims(bd.w)[1:2])
+    w, Paniso_raw = parent(bd.w), parent(Paniso)
 
     @inbounds for j in axes(w, 2), i in axes(w, 1)
         b̂ = normalize(SA[w[i, j, ibx], w[i, j, iby], w[i, j, ibz]])
@@ -350,7 +350,7 @@ function get_anisotropy(bd::BatsrusIDL{2, TV}, species = 0; method = :simple) wh
         end
     end
 
-    return DimArray(Paniso_raw, dims(bd.w)[1:2])
+    return Paniso
 end
 
 """

--- a/src/utility.jl
+++ b/src/utility.jl
@@ -84,7 +84,7 @@ function interp2d(
 end
 
 function _interp2d_structured(
-        bd::BatsrusIDLStructured{2, TV, TX, TW}, W_raw::AbstractArray,
+        bd::BatsrusIDLStructured{2, TV, TX, TW}, W_raw,
         plotrange::Vector, plotinterval::Real;
         innermask::Bool, rbody::Union{Nothing, Real}
     ) where {TV, TX, TW}
@@ -92,7 +92,7 @@ function _interp2d_structured(
     xi, yi, Wi = if all(isinf.(plotrange))
         xi_ = xrange
         yi_ = yrange
-        Wi_ = (W_raw isa Array ? W_raw : collect(W_raw))' # Matplotlib does not accept view!
+        Wi_ = collect(W_raw)'
         xi_, yi_, Wi_
     else
         adjust_plotrange!(plotrange, (xrange[1], xrange[end]), (yrange[1], yrange[end]))
@@ -107,8 +107,7 @@ function _interp2d_structured(
         else
             range(plotrange[3], stop = plotrange[4], step = plotinterval)
         end
-        W_raw = W_raw isa Array ? W_raw : collect(W_raw)
-        itp = scale(interpolate(W_raw, BSpline(Linear())), (xrange, yrange))
+        itp = scale(interpolate(parent(W_raw), BSpline(Linear())), (xrange, yrange))
         Wi_ = [itp(i, j) for j in yi_, i in xi_]
         xi_, yi_, Wi_
     end
@@ -266,11 +265,10 @@ end
 
 function _interp1d_point(
         bd::BatsrusIDLStructured{2, TV, TX, TW},
-        v::AbstractArray, loc::AbstractVector{<:AbstractFloat}
+        v, loc::AbstractVector{<:AbstractFloat}
     ) where {TV, TX, TW}
     xrange, yrange = get_range(bd)
-    v = v isa Array ? v : collect(v)
-    itp = scale(interpolate(v, BSpline(Linear())), (xrange, yrange))
+    itp = scale(interpolate(parent(v), BSpline(Linear())), (xrange, yrange))
 
     return itp(loc...)
 end
@@ -283,23 +281,15 @@ Interpolate `var` along a line from `point1` to `point2` in `bd`. `var` can be a
 """
 function interp1d(
         bd::BatsrusIDLStructured{2, TV, TX, TW},
-        var::Union{AbstractString, Symbol},
-        point1::Vector,
-        point2::Vector
+        var::Union{AbstractString, Symbol}, point1, point2
     ) where {TV, TX, TW}
     v = getvar(bd, var)
     return _interp1d_line(bd, v, point1, point2)
 end
 
-function _interp1d_line(
-        bd::BatsrusIDLStructured{2, TV, TX, TW},
-        v::AbstractArray,
-        point1::Vector,
-        point2::Vector
-    ) where {TV, TX, TW}
+function _interp1d_line(bd::BatsrusIDLStructured{2, TV, TX, TW}, v, point1, point2) where {TV, TX, TW}
     xrange, yrange = get_range(bd)
-    v = v isa Array ? v : collect(v)
-    itp = scale(interpolate(v, BSpline(Linear())), (xrange, yrange))
+    itp = scale(interpolate(parent(v), BSpline(Linear())), (xrange, yrange))
     lx = point2[1] - point1[1]
     ly = point2[2] - point1[2]
     nx = lx ÷ xrange.step |> Int
@@ -325,16 +315,12 @@ slice1d(bd, var::Union{AbstractString, Symbol}, icut::Int = 1, dir::Int = 2) =
 """
 Return view of variable `var` in `bd`.
 """
-function getview(bd::BatsrusIDL{1, TV}, var) where {TV}
-    varIndex_ = findindex(bd, var)
-
-    return v = @view bd.w[:, varIndex_]
-end
-
-function getview(bd::BatsrusIDL{2, TV}, var) where {TV}
-    varIndex_ = findindex(bd, var)
-
-    return v = @view bd.w[:, :, varIndex_]
+@generated function getview(bd::BatsrusIDL{ndim}, var) where {ndim}
+    colons = fill(:(:), ndim)
+    return quote
+        varIndex_ = findindex(bd, var)
+        return @view bd.w[$(colons...), varIndex_]
+    end
 end
 
 """
@@ -346,21 +332,8 @@ get_var_range(bd::BatsrusIDL, var::Union{AbstractString, Symbol}) =
 """
 Return mesh range of `bd`.
 """
-function get_range(bd::BatsrusIDLStructured{2, TV, TX, TW}) where {TV, TX, TW}
-    x = bd.x
-    xrange = range(x[1, 1, 1], x[end, 1, 1], length = size(x, 1))
-    yrange = range(x[1, 1, 2], x[1, end, 2], length = size(x, 2))
-
-    return xrange, yrange
-end
-
-function get_range(bd::BatsrusIDLStructured{3, TV, TX, TW}) where {TV, TX, TW}
-    x = bd.x
-    xrange = range(x[1, 1, 1, 1], x[end, 1, 1, 1], length = size(x, 1))
-    yrange = range(x[1, 1, 1, 2], x[1, end, 1, 2], length = size(x, 2))
-    zrange = range(x[1, 1, 1, 3], x[1, 1, end, 3], length = size(x, 3))
-
-    return xrange, yrange, zrange
+@generated function get_range(bd::BatsrusIDLStructured{ndim}) where {ndim}
+    return Expr(:tuple, [:(parent(val(dims(bd.x, $i)))) for i in 1:ndim]...)
 end
 
 """
@@ -541,7 +514,7 @@ where \$\\hat{\\mathbf{d}} \\propto \\mathbf{B} \\times \\mathbf{E}\$ and \$\\ha
 
 The returned function takes `(data, names)` and returns `(new_data, new_names)`.
 """
-function get_particle_field_aligned_transform(b_field::AbstractVector, e_field = nothing)
+function get_particle_field_aligned_transform(b_field, e_field = nothing)
     bhat = SVector{3}(normalize(b_field))
 
     if isnothing(e_field)

--- a/test/tests_plotting.jl
+++ b/test/tests_plotting.jl
@@ -217,9 +217,10 @@
             plt.close()
 
             mktempdir() do tmpdir
-                # 2D structured binary with streamlines
+                # 2D structured binary with streamlines and derived variable
                 animate(
                     [joinpath(datapath, file)], outdir = tmpdir,
+                    var = :b,
                     streamvars = "bx;by",
                     stream_kwargs = (; color = "red"),
                     plot_kwargs = (; cmap = "viridis"),


### PR DESCRIPTION
Now derived variables such as anisotropy and magnetic field magnitude are returned as raw arrays. This is not consistent with raw variable extraction that returns DimArray from DimensionalData.