### PR TITLE
refactor: use physical constants from Unitful

### DIFF
--- a/src/Batsrus.jl
+++ b/src/Batsrus.jl
@@ -1,7 +1,7 @@
+"""
+BATSRUS data reader and analyzer.
+"""
 module Batsrus
-# BATSRUS data reader and analyzer.
-#
-# Hongyang Zhou, hyzhou@umich.edu
 
 using LinearAlgebra: normalize, ×, ⋅, Adjoint, norm, diag, diagm, tr, dot
 using Printf, Reexport
@@ -11,6 +11,7 @@ import NaturalNeighbours as NN
 using StaticArrays: SVector, @SVector, @SMatrix, SA, MVector
 using DimensionalData
 using ProgressMeter
+using Unitful
 
 export BATS, BatsrusIDL, BatsrusIDLStructured, BatsrusIDLUnstructured,
     load, readlogdata, readtecdata, showhead, # io

--- a/src/derived.jl
+++ b/src/derived.jl
@@ -1,13 +1,5 @@
 # Derived quantities from raw output variables.
 
-# Earth radius in km used for current density scaling in PLANETARY units.
-const EARTH_RADIUS_KM = 6378.0
-# Elementary charge in C
-const ELEMENTARY_CHARGE = 1.602176634e-19
-# Factor to convert curl(B) to current density in μA/m²: 10 / (4π * Re)
-const FAC_J_PLANETARY = 10.0 / (4.0 * π * EARTH_RADIUS_KM)
-
-
 """
     get_magnitude2(bd::BatsrusIDL, var)
 
@@ -136,10 +128,10 @@ end
         return 1.0
     elseif bd.head.headline == "PLANETARY" || occursin(" nT ", bd.head.headline)
         # Factor to convert (nPa / Re) / (amu/cc * e) to μV/m
-        return 1.0e-12 / (EARTH_RADIUS_KM * ELEMENTARY_CHARGE)
+        return ustrip(u"μV/m", 1u"nPa" / (1Re * (1amucc / 1u"u") * q))
     else
         # Factor to convert (nPa / km) / (amu/cc * e) to μV/m
-        return 1.0e-12 / ELEMENTARY_CHARGE
+        return ustrip(u"μV/m", 1u"nPa" / (1u"km" * (1amucc / 1u"u") * q))
     end
 end
 
@@ -148,15 +140,10 @@ end
         return 1.0
     elseif hasJ || bd.head.headline == "PLANETARY"
         # Factor to convert (μA/m² * nT) / (amu/cc) to μV/m
-        # E [V/m] = (10⁻⁶ * 10⁻⁹) / (10⁶ * e) * (j*b/n) = 10⁻²¹ / e * (j*b/n)
-        # E [μV/m] = 10⁻¹⁵ / e * (j*b/n)
-        return 1.0e-15 / ELEMENTARY_CHARGE
+        return ustrip(u"μV/m", (1ampm2 * 1u"nT") / ((1amucc / 1u"u") * q))
     else
         # Factor to convert (raw_J * nT) / (amu/cc) to μV/m
-        # J_SI = (raw_J * 10⁻⁹ / 10³) / μ₀ = raw_J * 10⁻¹² / (4π*10⁻⁷)
-        # E [V/m] = (raw_J * 10⁻¹² / μ₀ * 10⁻⁹) / (10⁶ * e) = 10⁻²⁷ / (μ₀*e) * (j*b/n)
-        # E [μV/m] = 10⁻²¹ / (μ₀*e) * (j*b/n)
-        return 1.0e-21 / (4.0 * π * 1.0e-7 * ELEMENTARY_CHARGE)
+        return ustrip(u"μV/m", (1u"nT" / (1u"km" * μ0) * 1u"nT") / ((1amucc / 1u"u") * q))
     end
 end
 
@@ -190,7 +177,10 @@ end
 @inline function _calc_anisotropy(Bx, By, Bz, pxx, pyy, pzz, pxy, pxz, pyz, method)
     if method === :projection
         B2 = Bx^2 + By^2 + Bz^2
-        p_parallel = (pxx * Bx^2 + pyy * By^2 + pzz * Bz^2 + 2 * pxy * Bx * By + 2 * pxz * Bx * Bz + 2 * pyz * By * Bz) / B2
+        p_parallel = (
+            pxx * Bx^2 + pyy * By^2 + pzz * Bz^2 +
+                2 * pxy * Bx * By + 2 * pxz * Bx * Bz + 2 * pyz * By * Bz
+        ) / B2
         return (pxx + pyy + pzz - p_parallel) / (2 * p_parallel)
     elseif method === :rotation
         P = @SMatrix [pxx pxy pxz; pxy pyy pyz; pxz pyz pzz]

--- a/src/derived.jl
+++ b/src/derived.jl
@@ -127,11 +127,9 @@ end
     if startswith(bd.head.headline, "normalized")
         return 1.0
     elseif bd.head.headline == "PLANETARY" || occursin(" nT ", bd.head.headline)
-        # Factor to convert (nPa / Re) / (amu/cc * e) to μV/m
-        return ustrip(u"μV/m", 1u"nPa" / (1Re * (1amucc / 1u"u") * q))
+        return FAC_PE_PLANETARY
     else
-        # Factor to convert (nPa / km) / (amu/cc * e) to μV/m
-        return ustrip(u"μV/m", 1u"nPa" / (1u"km" * (1amucc / 1u"u") * q))
+        return FAC_PE_DEFAULT
     end
 end
 
@@ -139,11 +137,9 @@ end
     if startswith(bd.head.headline, "normalized")
         return 1.0
     elseif hasJ || bd.head.headline == "PLANETARY"
-        # Factor to convert (μA/m² * nT) / (amu/cc) to μV/m
-        return ustrip(u"μV/m", (1ampm2 * 1u"nT") / ((1amucc / 1u"u") * q))
+        return FAC_HALL_PLANETARY
     else
-        # Factor to convert (raw_J * nT) / (amu/cc) to μV/m
-        return ustrip(u"μV/m", (1u"nT" / (1u"km" * μ0) * 1u"nT") / ((1amucc / 1u"u") * q))
+        return FAC_HALL_DEFAULT
     end
 end
 

--- a/src/unit/UnitfulBatsrus.jl
+++ b/src/unit/UnitfulBatsrus.jl
@@ -1,9 +1,12 @@
 module UnitfulBatsrus
 
 using Unitful: Unitful
-import Unitful: q, c, μ0, ϵ0, k, me, mp
+import Unitful: q, c, μ0, ϵ0, k, me, mp, ustrip
 using Unitful: @unit, Unitlike
 export getunit, getunits
+export q, c, μ0, ϵ0, k, me, mp
+export Re, Rg, RMercury, RSun, AU, amucc, kms, ampm2, tm2, vm2
+export EARTH_RADIUS_KM, ELEMENTARY_CHARGE, FAC_J_PLANETARY
 
 # lengths
 @unit Re "Re" EarthRadii (6378) * Unitful.km false
@@ -33,6 +36,13 @@ export getunit, getunits
 # Others
 @unit tm2 "nT/m²" MagneticFieldDivergence 1 * Unitful.nT / Unitful.m^2 false
 @unit vm2 "V/m²" ElectricFieldDivergence 1 * Unitful.V / Unitful.m^2 false
+
+# Earth radius in km used for current density scaling in PLANETARY units.
+const EARTH_RADIUS_KM = ustrip(Unitful.km, 1Re)
+# Elementary charge in C
+const ELEMENTARY_CHARGE = ustrip(Unitful.C, 1q)
+# Factor to convert curl(B) to current density in μA/m²: 10 / (4π * Re)
+const FAC_J_PLANETARY = ustrip(ampm2, 1Unitful.nT / (1Re * μ0))
 
 const _UNIT_MAP = Dict(
     "R" => Re,

--- a/src/unit/UnitfulBatsrus.jl
+++ b/src/unit/UnitfulBatsrus.jl
@@ -6,7 +6,8 @@ using Unitful: @unit, Unitlike
 export getunit, getunits
 export q, c, μ0, ϵ0, k, me, mp
 export Re, Rg, RMercury, RSun, AU, amucc, kms, ampm2, tm2, vm2
-export EARTH_RADIUS_KM, ELEMENTARY_CHARGE, FAC_J_PLANETARY
+export EARTH_RADIUS_KM, ELEMENTARY_CHARGE, FAC_J_PLANETARY,
+    FAC_PE_PLANETARY, FAC_PE_DEFAULT, FAC_HALL_PLANETARY, FAC_HALL_DEFAULT
 
 # lengths
 @unit Re "Re" EarthRadii (6378) * Unitful.km false
@@ -43,6 +44,14 @@ const EARTH_RADIUS_KM = ustrip(Unitful.km, 1Re)
 const ELEMENTARY_CHARGE = ustrip(Unitful.C, 1q)
 # Factor to convert curl(B) to current density in μA/m²: 10 / (4π * Re)
 const FAC_J_PLANETARY = ustrip(ampm2, 1Unitful.nT / (1Re * μ0))
+# Factor to convert (nPa / Re) / (amu/cc * e) to μV/m
+const FAC_PE_PLANETARY = ustrip(Unitful.μV / Unitful.m, 1Unitful.nPa / (1Re * 1Unitful.cm^-3 * q))
+# Factor to convert (nPa / km) / (amu/cc * e) to μV/m
+const FAC_PE_DEFAULT = ustrip(Unitful.μV / Unitful.m, 1Unitful.nPa / (1Unitful.km * 1Unitful.cm^-3 * q))
+# Factor to convert (μA/m² * nT) / (amu/cc) to μV/m
+const FAC_HALL_PLANETARY = ustrip(Unitful.μV / Unitful.m, (1ampm2 * 1Unitful.nT) / (1Unitful.cm^-3 * q))
+# Factor to convert (raw_J * nT) / (amu/cc) to μV/m
+const FAC_HALL_DEFAULT = ustrip(Unitful.μV / Unitful.m, (1Unitful.nT / (1Unitful.km * μ0) * 1Unitful.nT) / (1Unitful.cm^-3 * q))
 
 const _UNIT_MAP = Dict(
     "R" => Re,


### PR DESCRIPTION
Use physical constants from Unitful instead of defining new ones locally.